### PR TITLE
feat: permissions request at Android 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ InfoPlist:
 
 ### Android
 
-AndroidManifest: `<uses-permission android:name="android.permission.CAMERA"/>`
+AndroidManifest: 
+- `<uses-permission android:name="android.permission.CAMERA"/>`
+- `<uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>`
 
 Project build.gradle:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Learn more about:
 1. Install with Expo
 
 ```sh
-$ expo install with-rn-image-crop-picker
+$ expo install with-rn-image-crop-picker expo-build-properties
 ```
 
 2. Check your app.json. It should look like this:
@@ -50,6 +50,15 @@ $ expo install with-rn-image-crop-picker
  "plugins": [
       "with-rn-image-crop-picker"
     ],
+    [
+      "expo-build-properties",
+      {
+        "android": {
+          "compileSdkVersion": 33,
+          "targetSdkVersion": 33
+        }
+      }
+]
 ```
 
 3. Rebuild your app

--- a/src/android/withUpdateAndroidManifest.ts
+++ b/src/android/withUpdateAndroidManifest.ts
@@ -14,6 +14,7 @@ async function setCustomConfigAsync(
 	androidManifest: AndroidConfig.Manifest.AndroidManifest
 ): Promise<AndroidConfig.Manifest.AndroidManifest> {
 	addPermission(androidManifest, 'android.permission.CAMERA');
+	addPermission(androidManifest, 'android.permission.READ_MEDIA_IMAGES')
 
 	return androidManifest;
 }


### PR DESCRIPTION
Fix next problems with requesting permission to access photo library at Android >= 13
- Error message during build.
```
[stderr] /home/expo/workingdir/build/node_modules/react-native-image-crop-picker/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java:406: error: cannot find symbol
[stderr] permissionsCheck(activity, promise, Collections.singletonList(Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ? Manifest.permission.WRITE_EXTERNAL_STORAGE : Manifest.permission.READ_MEDIA_IMAGES), new Callable<Void>() {
[stderr]                                                                                                    ^
[stderr]   symbol:   variable TIRAMISU
[stderr]   location: class VERSION_CODES
```
- Error in runtime "Required Permissions Missing" when calling `ImagePicker.openPicker`